### PR TITLE
Add code coverage and integrate with sonarcloud

### DIFF
--- a/.github/workflows/java_ci.yml
+++ b/.github/workflows/java_ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=DivyenduDutta_Github-Assistant-MCP-Server      
+        run: mvn -B verify -Pcoverage sonar:sonar -Dsonar.projectKey=DivyenduDutta_Github-Assistant-MCP-Server      
 
       - name: Run Spotless (lint check)
         run: mvn spotless:check

--- a/.github/workflows/java_ci.yml
+++ b/.github/workflows/java_ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build and analyze
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify -Pcoverage sonar:sonar -Dsonar.projectKey=DivyenduDutta_Github-Assistant-MCP-Server      
+        run: mvn -B verify -Pcoverage org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=DivyenduDutta_Github-Assistant-MCP-Server      
 
       - name: Run Spotless (lint check)
         run: mvn spotless:check

--- a/.github/workflows/java_ci.yml
+++ b/.github/workflows/java_ci.yml
@@ -20,18 +20,10 @@ jobs:
           distribution: 'temurin'
           cache: maven
         
-      - name: Build with Maven + Coverage
-        run: mvn -B clean verify -Pcoverage --file pom.xml
-        
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        with:
-          args: >
-            -Dsonar.projectKey=DivyenduDutta_Github-Assistant-MCP-Server
-            -Dsonar.organization=divyendudutta
-            -Dsonar.host.url=https://sonarcloud.io
-            -Dsonar.login=${{ secrets.SONAR_TOKEN }}
-            -Dsonar.java.binaries=target/classes
+      - name: Build and analyze
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=DivyenduDutta_Github-Assistant-MCP-Server      
 
       - name: Run Spotless (lint check)
         run: mvn spotless:check

--- a/.github/workflows/java_ci.yml
+++ b/.github/workflows/java_ci.yml
@@ -31,6 +31,7 @@ jobs:
             -Dsonar.organization=divyendudutta
             -Dsonar.host.url=https://sonarcloud.io
             -Dsonar.login=${{ secrets.SONAR_TOKEN }}
+            -Dsonar.java.binaries=target/classes
 
       - name: Run Spotless (lint check)
         run: mvn spotless:check

--- a/.github/workflows/java_ci.yml
+++ b/.github/workflows/java_ci.yml
@@ -19,9 +19,9 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
           cache: maven
-
-      - name: Build with Maven
-        run: mvn -B clean verify --file pom.xml
+        
+      - name: Build with Maven + Coverage
+        run: mvn -B clean verify -Pcoverage --file pom.xml
 
       - name: Run Spotless (lint check)
         run: mvn spotless:check

--- a/.github/workflows/java_ci.yml
+++ b/.github/workflows/java_ci.yml
@@ -22,6 +22,15 @@ jobs:
         
       - name: Build with Maven + Coverage
         run: mvn -B clean verify -Pcoverage --file pom.xml
+        
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        with:
+          args: >
+            -Dsonar.projectKey=DivyenduDutta_Github-Assistant-MCP-Server
+            -Dsonar.organization=divyendudutta
+            -Dsonar.host.url=https://sonarcloud.io
+            -Dsonar.login=${{ secrets.SONAR_TOKEN }}
 
       - name: Run Spotless (lint check)
         run: mvn spotless:check

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ build/
 
 ### Misc output files
 /output
+/code_coverage

--- a/README.md
+++ b/README.md
@@ -94,9 +94,15 @@ Always ensure to add or update unit tests for any new code/features and run all 
 
 Run 
 ```bash
-mvn clean package -DskipTests
+mvn -B clean verify -Pcoverage --file pom.xml
 ```
-to build the project and generate the jar file.
+to build the project, generate the jar file and get the test coverage report (SonarCloud uses this report to display 
+code coverage metrics). 
+
+The code coverage report can be 
+found in `{project.basedir}/code_coverage`. SonarCloud is also integrated for
+static code analysis and code coverage reporting. The SonarCloud badge at the top of this README reflects the current
+status of the project on SonarCloud.
 
 Process:
 

--- a/README.md
+++ b/README.md
@@ -86,23 +86,29 @@ mvnw spotbugs:check
 mvnw pmd:check
 ```
 
-#### Unit tests
+#### Unit tests and Code coverage
 
 Always ensure to add or update unit tests for any new code/features and run all tests before pushing to remote.
+
+Run the below command to execute unit tests and generate code coverage report (for local analysis, if needed).
+```bash
+mvn clean test -Pcoverage
+```
+
+The code coverage report can be
+found in `{project.basedir}/code_coverage`. 
+
+SonarCloud is also integrated for
+static code analysis and code coverage reporting. The SonarCloud badge at the top of this README reflects the current
+status of the project on SonarCloud. All the SonarCloud integration is already handled by Github CI.
 
 ## Usage
 
 Run 
 ```bash
-mvn -B clean verify -Pcoverage --file pom.xml
+mvn clean package -DskipTests
 ```
-to build the project, generate the jar file and get the test coverage report (SonarCloud uses this report to display 
-code coverage metrics). 
-
-The code coverage report can be 
-found in `{project.basedir}/code_coverage`. SonarCloud is also integrated for
-static code analysis and code coverage reporting. The SonarCloud badge at the top of this README reflects the current
-status of the project on SonarCloud.
+to build the project and generate the jar file.
 
 Process:
 

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,43 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-
+    
+    <profiles>
+        <profile>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>0.8.7</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <phase>test</phase>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.basedir}/code_coverage</outputDirectory>
+                                    <formats>
+                                        <format>XML</format>
+                                    </formats>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    
 	<build>
 		<plugins>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
 	<properties>
 		<java.version>17</java.version>
 		<spring-ai.version>2.0.0-M3</spring-ai.version>
+        <sonar.organization>divyendudutta</sonar.organization>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,9 @@
 		<java.version>17</java.version>
 		<spring-ai.version>2.0.0-M3</spring-ai.version>
         <sonar.organization>divyendudutta</sonar.organization>
+        <sonar.coverage.jacoco.xmlReportPaths>
+            ${project.basedir}/code_coverage
+        </sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<spring-ai.version>2.0.0-M3</spring-ai.version>
         <sonar.organization>divyendudutta</sonar.organization>
         <sonar.coverage.jacoco.xmlReportPaths>
-            ${project.basedir}/code_coverage
+            ${project.basedir}/code_coverage/jacoco.xml
         </sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 	<dependencies>


### PR DESCRIPTION
Closes #5 

Added Jacoco code coverage to run as part of build process and integrated the resulting code coverage report to show up on sonarcloud dashboard.

